### PR TITLE
app/javascript内のファイルを空欄に

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,0 @@
-// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import "@hotwired/turbo-rails";
-import "./controllers";

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,9 +1,0 @@
-import { Application } from "@hotwired/stimulus"
-
-const application = Application.start()
-
-// Configure Stimulus development experience
-application.debug = false
-window.Stimulus   = application
-
-export { application }


### PR DESCRIPTION
日記作成フォーム内のscript要素のリファクタリングに伴い、不必要なjavasscriptファイルを空欄にしました。

空欄にしたファイル
・app/javascript/application.js
・app/javascript/controllers/application.js