### PR TITLE
パスワードリセットコントローラーのリファクタリング

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,5 +1,6 @@
 class PasswordResetsController < ApplicationController
   skip_before_action :require_login
+  before_action :load_user_from_token, only: [ :edit, :update ]
 
   def new; end
 
@@ -10,23 +11,26 @@ class PasswordResetsController < ApplicationController
   end
 
   def edit
-    @token = params[:id]
-    @user = User.load_from_reset_password_token(@token)
     not_authenticated if @user.blank?
   end
 
   def update
-    @token = params[:id]
-    @user = User.load_from_reset_password_token(@token)
-
     return not_authenticated if @user.blank?
 
     @user.password_confirmation = params[:user][:password_confirmation]
+
     if @user.change_password(params[:user][:password])
       redirect_to login_path, success: t(".success")
     else
       flash.now[:danger] = t(".fail")
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  private
+
+  def load_user_from_token
+    @token = params[:id]
+    @user = User.load_from_reset_password_token(@token)
   end
 end


### PR DESCRIPTION
DRY原則に沿うようにするため、edit、updateアクションに記述されている次のコードを一つに統一しました。
```
@token = params[:id]
@user = User.load_from_reset_password_token(@token)
```