### PR TITLE
カードレイアウトに変更

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,40 +1,34 @@
 <%= form_with model: @post do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
 
-  <div class="mb-auto">
-    <%= f.label :title %>
-    <%= f.text_field :title, class: "form-control" %>
-  </div>
+  <% if @post.image_url.present? %>
+    <div class="mb-3">
+      <p><%= t("posts._form.current_image") %></p>
+      <img src="<%= @post.image_url %>" alt="Image" class="img-fluid rounded-3" style="max-width: 200px;" />
+    </div>
+  <% end %>
 
-  <div class="mb-auto">
-    <%= f.label :image %>
+  <div class="mb-3">
+    <%= f.label :image, class: "form-label" %>
     <%= f.file_field :image, class: "form-control", accept: 'image/*' %>
   </div>
 
-  <% if @post.image_url.present? %>
-    <div class="mb-auto">
-      <p><%= t("posts._form.current_image") %></p>
-      <img src="<%= @post.image_url %>" alt="Image" width="200" />     
-    </div>
-  <% end %>
-  
-  <div class="mb-auto d-flex flex-wrap gap-2">
-    <div>
-      <%= f.label :plant_name %>
-      <%= f.text_field :plant_name, class: "form-control", placeholder: "カタカナで入力" %>
-    </div>
-
+  <div class="mb-3">
+    <%= f.label :title, class: "form-label" %>
+    <%= f.text_field :title, class: "form-control" %>
   </div>
 
-  <div class="mb-auto">
-    <%= f.label :body %>
+  <div class="mb-3">
+    <%= f.label :plant_name, class: "form-label" %>
+    <%= f.text_field :plant_name, class: "form-control", placeholder: "カタカナで入力" %>
+  </div>
+
+  <div class="mb-4">
+    <%= f.label :body, class: "form-label" %>
     <%= f.text_area :body, class: "form-control", rows: "10" %>
   </div>
 
-
-
-  <button type="button" class="btn btn-secondary" id="add-growth-stage-content"><%= t('buttons.add') %></button>
-  <%= f.submit t('buttons.save'), class: "btn btn-success" %>
+  <div class="d-flex gap-2 justify-content-center">
+    <%= f.submit t('buttons.save'), class: "btn btn-success" %>
+  </div>
 <% end %>
-
-

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,9 +1,15 @@
 <% content_for(:title, t('.title')) %>
-<div class="container">
-  <div class="row">
-    <div class="col-lg-8 offset-lg-2">
-      <h1 class="text-success"><%= t('.title') %></h1>
-      <%= render 'form', post: @post %>
+<div class="container py-5">
+  <div class="row justify-content-center">
+    <div class="col-lg-8 text-success-emphasis">
+      <h1 class="fw-bold mb-4"><%= t('.title') %></h1>
+
+      <div class="card shadow-sm rounded-4">
+        <div class="card-body p-4">
+          <%= render 'form', post: @post %>
+        </div>
+      </div>
+
     </div>
   </div>
 </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,8 +1,14 @@
-<div class="container">
-  <div class="row">
-    <div class="col-lg-8 offset-lg-2">
-      <h1 class="text-success"><%= t('.title') %></h1>
-      <%= render 'form', post: @post %>
+<div class="container py-5">
+  <div class="row justify-content-center">
+    <div class="col-lg-8 text-success-emphasis">
+      <h1 class="fw-bold mb-4"><%= t('.title') %></h1>
+
+      <div class="card shadow-sm rounded-4">
+        <div class="card-body p-4">
+          <%= render 'form', post: @post %>
+        </div>
+      </div>
+
     </div>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,45 +1,33 @@
-<div class="container pt-5">
-  <div class="row mb-3">
-    <div class="col-lg-12 offset-auto">
-      <h1 class="text-success"><%= t('.title') %></h1>
+<div class="container py-5">
+  <div class="row justify-content-center">
+    <div class="col-lg-10 text-success-emphasis">
+      <h1 class="fw-bold mb-4"><%= t('.title') %></h1>
 
-      <article class="card">
-        <div class="card-body">
-          <div class="row">
-            <div class="col-md-5">
-              <%= image_tag @post.image.url, width: "300", height: "200", class: "card-img-top img-fluid" %>
-            </div>
-            <div class="col-md-7">
-              <h3 style="display: inline;"><%= @post.title %></h3>
-              <ul class="list-inline">
+      <article class="card shadow-sm rounded-4 overflow-hidden">
+        <div class="row g-0">
+          <div class="col-md-5">
+            <%= image_tag @post.image.url, class: "img-fluid w-100 h-100", style: "object-fit: cover; min-height: 300px;" %>
+          </div>
+          <div class="col-md-7 d-flex flex-column text-success-emphasis">
+            <div class="card-body p-4 d-flex flex-column h-100">
+              <h3 class="fw-bold mb-2"><%= @post.title %></h3>
+              <ul class="list-inline text-muted small mb-3">
                 <li class="list-inline-item"><%= t('.created_by', user_name: @post.user.decorate.name) %></li>
+                <li class="list-inline-item">・</li>
                 <li class="list-inline-item"><%= l @post.created_at, format: :long %></li>
               </ul>
 
-              <ul class="list-unstyled">
-                <li><strong><%= t('.plant_name') %>:</strong> <%= @post.plant_name %></li>
-                <p><%= simple_format(@post.body) %></p>
-              </ul>
-              <div class='d-flex justify-content-end'>
-                <%= link_to edit_post_path(@post), id: "button-edit-#{@post.id}", class: "btn btn-success me-2" do %>
-                  <i class='bi bi-pencil-fill'></i> <%= t('defaults.edit') %>
+              <p class="mb-1"><strong><%= t('.plant_name') %>:</strong> <%= @post.plant_name %></p>
+              <div class="mb-4"><%= simple_format(@post.body) %></div>
+
+              <div class="d-flex justify-content-end gap-2 mt-auto flex-wrap">
+                <%= link_to edit_post_path(@post), id: "button-edit-#{@post.id}", class: "btn btn-success" do %>
+                  <i class="bi bi-pencil-fill"></i> <%= t('defaults.edit') %>
                 <% end %>
-                <%= link_to post_path(@post), id: "button-delete-#{@post.id}", class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do%>
+                <%= link_to post_path(@post), id: "button-delete-#{@post.id}", class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
                   <i class="bi bi-trash-fill"></i> <%= t('defaults.delete') %>
                 <% end %>
               </div>
-              <style>
-                .btn {
-                  white-space: nowrap; 
-                  min-width: 120px; 
-                }
-
-                @media (max-width: 375px) {
-                  .d-flex {
-                  flex-wrap: nowrap; 
-                  }
-                }
-              </style>
             </div>
           </div>
         </div>


### PR DESCRIPTION
新規投稿・編集画面並びに、詳細画面のレイアウトをカードスタイルにしてスッキリさせました。

次の作業は、新規投稿画面の画像アップロード部分のUIを改良したいと思います。